### PR TITLE
Use API_BASE_URL for backend requests

### DIFF
--- a/frontend/ShramiKare/src/pages/OutbreakDashboardPage.jsx
+++ b/frontend/ShramiKare/src/pages/OutbreakDashboardPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
+import { API_BASE_URL } from "../config";
 
 export default function OutbreakDashboardPage() {
     const [data, setData] = useState(null);
@@ -14,7 +15,7 @@ export default function OutbreakDashboardPage() {
     const fetchData = async () => {
         try {
             setLoading(true);
-            const res = await fetch("http://localhost:8000/api/outbreak-metrics/");
+            const res = await fetch(`${API_BASE_URL}/outbreak-metrics/`);
             const json = await res.json();
             setData(json);
         } catch (error) {
@@ -28,7 +29,7 @@ export default function OutbreakDashboardPage() {
         if (!confirm("Are you sure you want to send emergency SMS alerts to all users pending follow-ups?")) return;
         try {
             setAlertSending(true);
-            const res = await fetch("http://localhost:8000/api/send-followup-reminders/");
+            const res = await fetch(`${API_BASE_URL}/send-followup-reminders/`);
             const result = await res.json();
             setAlertSuccess(result.message || "Alerts sent successfully!");
             setTimeout(() => setAlertSuccess(""), 5000);

--- a/frontend/ShramiKare/src/pages/QrScannerPage.jsx
+++ b/frontend/ShramiKare/src/pages/QrScannerPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import jsQR from "jsqr";
-
+import { API_BASE_URL } from "../config";
 export default function QrScannerPage() {
     const [scanResult, setScanResult] = useState(null);
     const [scanning, setScanning] = useState(false);
@@ -80,7 +80,7 @@ export default function QrScannerPage() {
                 aadhaarId = parts[parts.length - 1];
             }
 
-            const res = await fetch(`http://localhost:8000/api/users/by-aadhaar/${aadhaarId}`);
+            const res = await fetch(`${API_BASE_URL}/users/by-aadhaar/${aadhaarId}`);
             if (!res.ok) throw new Error("User not found");
             const data = await res.json();
             if (data && data.length > 0) {


### PR DESCRIPTION
Replace hardcoded http://localhost:8000 endpoints with a configurable API_BASE_URL. Added import of API_BASE_URL from ../config in OutbreakDashboardPage.jsx and QrScannerPage.jsx, and updated fetch calls to use `${API_BASE_URL}/outbreak-metrics/`, `${API_BASE_URL}/send-followup-reminders/`, and `${API_BASE_URL}/users/by-aadhaar/{id}`. Also contains a minor whitespace cleanup in QrScannerPage.jsx. This makes the backend host configurable for different environments.